### PR TITLE
Updating container def family and removing role_arn from autoscaling resource

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,5 +1,5 @@
 locals {
-  cluster_name = var.ecs_cluster_name == null ? split("/", var.ecs_cluster_arn)[1] : var.ecs_cluster_name
+  cluster_name = split("/", var.ecs_cluster_arn)[1]
 }
 
 resource "aws_iam_role" "autoscale" {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -33,7 +33,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
   resource_id        = "service/${local.cluster_name}/${aws_ecs_service.default[0].name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
-  role_arn           = aws_iam_role.autoscale.arn
+  role_arn           = aws_iam_role.autoscale[count.index].arn
 }
 
 resource "aws_appautoscaling_policy" "ecs_target_cpu" {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -33,7 +33,6 @@ resource "aws_appautoscaling_target" "ecs_target" {
   resource_id        = "service/${local.cluster_name}/${aws_ecs_service.default[0].name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
-  role_arn           = aws_iam_role.autoscale[count.index].arn
 }
 
 resource "aws_appautoscaling_policy" "ecs_target_cpu" {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -40,9 +40,9 @@ resource "aws_appautoscaling_policy" "ecs_target_cpu" {
   count              = var.autoscaling_enabled ? 1 : 0
   name               = "application-scaling-policy-cpu"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+  resource_id        = aws_appautoscaling_target.ecs_target[count.index].resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target[count.index].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target[count.index].service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -57,9 +57,9 @@ resource "aws_appautoscaling_policy" "ecs_target_memory" {
   count              = var.autoscaling_enabled ? 1 : 0
   name               = "application-scaling-policy-memory"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
-  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+  resource_id        = aws_appautoscaling_target.ecs_target[count.index].resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target[count.index].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target[count.index].service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,0 +1,71 @@
+locals {
+  cluster_name = var.ecs_cluster_name == null ? split("/", var.ecs_cluster_arn)[1] : var.ecs_cluster_name
+}
+
+resource "aws_iam_role" "autoscale" {
+  count              = var.autoscaling_enabled ? 1 : 0
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "application-autoscaling.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "autoscale" {
+  count      = var.autoscaling_enabled ? 1 : 0
+  role       = aws_iam_role.autoscale.id
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
+}
+
+resource "aws_appautoscaling_target" "ecs_target" {
+  count              = var.autoscaling_enabled ? 1 : 0
+  max_capacity       = var.autoscaling.max_capacity
+  min_capacity       = var.autoscaling.min_capacity
+  resource_id        = "service/${local.cluster_name}/${aws_ecs_service.default[0].name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+  role_arn           = aws_iam_role.autoscale.arn
+}
+
+resource "aws_appautoscaling_policy" "ecs_target_cpu" {
+  count              = var.autoscaling_enabled ? 1 : 0
+  name               = "application-scaling-policy-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value = var.autoscaling.target_cpu
+  }
+  depends_on = [aws_appautoscaling_target.ecs_target]
+}
+
+resource "aws_appautoscaling_policy" "ecs_target_memory" {
+  count              = var.autoscaling_enabled ? 1 : 0
+  name               = "application-scaling-policy-memory"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+    target_value = var.autoscaling.target_memory
+  }
+  depends_on = [aws_appautoscaling_target.ecs_target]
+}

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -22,7 +22,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "autoscale" {
   count      = var.autoscaling_enabled ? 1 : 0
-  role       = aws_iam_role.autoscale.id
+  role       = aws_iam_role.autoscale[0].id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
 }
 

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -22,7 +22,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "autoscale" {
   count      = var.autoscaling_enabled ? 1 : 0
-  role       = aws_iam_role.autoscale[0].id
+  role       = aws_iam_role.autoscale[count.index].id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ module "exec_label" {
 
 resource "aws_ecs_task_definition" "default" {
   count                    = local.create_task_definition ? 1 : 0
-  family                   = module.this.id
+  family                   = module.this.name
   container_definitions    = var.container_definition_json
   requires_compatibilities = [var.launch_type]
   network_mode             = var.network_mode

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "ecs_cluster_arn" {
   description = "The ARN of the ECS cluster where service will be provisioned"
 }
 
+variable "ecs_cluster_name" {
+  type        = string
+  description = "The name of the ECS cluster where service will be provisioned"
+}
+
 variable "ecs_load_balancers" {
   type = list(object({
     container_name   = string
@@ -551,4 +556,28 @@ variable "pid_mode" {
     condition     = var.pid_mode == null || contains(["host", "task"], coalesce(var.pid_mode, "null"))
     error_message = "The pid_mode value must be one of host or task."
   }
+}
+
+variable "autoscaling" {
+  type = object({
+    min_capacity  = number
+    max_capacity  = number
+    desired_count = number
+    target_cpu    = number
+    target_memory = number
+  })
+  description = "Scaling configuration for ECS services."
+  default = {
+    min_capacity  = 1
+    max_capacity  = 10
+    desired_count = 1
+    target_cpu    = 60
+    target_memory = 60
+  }
+}
+
+variable "autoscaling_enabled" {
+  type        = bool
+  description = "Whether to create resources related to deploying autoscaling functionality."
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,6 @@ variable "ecs_cluster_arn" {
   description = "The ARN of the ECS cluster where service will be provisioned"
 }
 
-variable "ecs_cluster_name" {
-  type        = string
-  description = "The name of the ECS cluster where service will be provisioned"
-}
-
 variable "ecs_load_balancers" {
   type = list(object({
     container_name   = string


### PR DESCRIPTION
## what

Updating the family name for container definitions to use just the module name instead of "kin-ue2-devplatform-rater***." And also removing option from autoscaling resource that could be causing issues.

## why

So we can start testing out autoscaling for rater.

## references

https://kininsurance.atlassian.net/browse/DK-380
