### PR TITLE
Adding ecs service ignore

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -454,7 +454,7 @@ resource "aws_ecs_service" "ignore_changes_task_definition" {
   triggers = local.redeployment_trigger
 
   lifecycle {
-    ignore_changes = [task_definition]
+    ignore_changes = [task_definition, load_balancer]
   }
 
   # Avoid race condition on destroy.

--- a/main.tf
+++ b/main.tf
@@ -559,10 +559,6 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
   # Avoid race condition on destroy.
   # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service
   depends_on = [aws_iam_role.ecs_service, aws_iam_role_policy.ecs_service]
-
-  lifecycle {
-    ignore_changes = [task_definition, desired_count, load_balancer]
-  }
 }
 
 resource "aws_ecs_service" "ignore_changes_desired_count" {

--- a/main.tf
+++ b/main.tf
@@ -559,6 +559,10 @@ resource "aws_ecs_service" "ignore_changes_task_definition_and_desired_count" {
   # Avoid race condition on destroy.
   # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service
   depends_on = [aws_iam_role.ecs_service, aws_iam_role_policy.ecs_service]
+
+  lifecycle {
+    ignore_changes = [task_definition, desired_count, load_balancer]
+  }
 }
 
 resource "aws_ecs_service" "ignore_changes_desired_count" {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Adds an ignore lifecycle rule for terraform to stop losing it's mind when CodeDeploy shifts the listener rules for blue/green deploys in dot-com.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Dot-com isn't using this new repo set up yet, but it will eventually. I've been working on it.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

https://kininsurance.atlassian.net/browse/DK-358
https://kin.app.spacelift.io/stack/ue2-devplatform-dot-com/run/01HSCB0RVSF84CSH2WY1JVJSS7
