### PR TITLE
Updating resource_id for autoscaling_target resource

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -30,7 +30,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
   count              = var.autoscaling_enabled ? 1 : 0
   max_capacity       = var.autoscaling.max_capacity
   min_capacity       = var.autoscaling.min_capacity
-  resource_id        = "service/${local.cluster_name}/${aws_ecs_service.default[0].name}"
+  resource_id        = "service/${local.cluster_name}/${aws_ecs_service.ignore_changes_desired_count[0].name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -30,7 +30,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
   count              = var.autoscaling_enabled ? 1 : 0
   max_capacity       = var.autoscaling.max_capacity
   min_capacity       = var.autoscaling.min_capacity
-  resource_id        = "service/${local.cluster_name}/${aws_ecs_service.ignore_changes_desired_count[0].name}"
+  resource_id        = "service/${local.cluster_name}/${try(aws_ecs_service.default[0].name, aws_ecs_service.ignore_changes_task_definition[0].name, aws_ecs_service.ignore_changes_desired_count[0].name, aws_ecs_service.ignore_changes_task_definition_and_desired_count[0].name, "")}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Renaming resource_id.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Because right now, the autoscaling is set to use the ignore_desired_count service rather than the default that doesn't exist for apps with autoscaling enabled.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
https://kininsurance.atlassian.net/browse/DK-504