### PR TITLE
adding sg_name for dot-com

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -310,7 +310,7 @@ resource "aws_iam_role_policy_attachment" "ecs_exec" {
 resource "aws_security_group" "ecs_service" {
   count       = local.create_security_group ? 1 : 0
   vpc_id      = var.vpc_id
-  name        = var.sg_name != "" ? var.sg_name : module.service_label.id
+  name        = var.sg_name != null ? var.sg_name : module.service_label.id
   description = var.security_group_description
   tags        = module.service_label.tags
 

--- a/main.tf
+++ b/main.tf
@@ -310,7 +310,7 @@ resource "aws_iam_role_policy_attachment" "ecs_exec" {
 resource "aws_security_group" "ecs_service" {
   count       = local.create_security_group ? 1 : 0
   vpc_id      = var.vpc_id
-  name        = module.service_label.id
+  name        = var.sg_name != "" ? var.sg_name : module.service_label.id
   description = var.security_group_description
   tags        = module.service_label.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -576,3 +576,9 @@ variable "autoscaling_enabled" {
   description = "Whether to create resources related to deploying autoscaling functionality."
   default     = false
 }
+
+variable "sg_name" {
+  type        = string
+  description = "Name of security group that the service should use."
+  default     = null
+}


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

The dot-com security group is wanting to change based on the service_label.id which is fine for everything else expect dot-com. So I'm giving it a variable option.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Because it's causing dot-com to want to rebuild the sg when it doesn't need to.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
