### PR TITLE
PLATO-33 | Change AppSpec Location and Update Provider Type for CodePipeline

### DIFF
--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -95,7 +95,7 @@ resource "aws_codepipeline" "default" {
       output_artifacts = ["SourceOutput"]
       configuration = {
         S3Bucket    = aws_s3_bucket.appspec_artifacts[0].bucket
-        S3ObjectKey = "source/appspec.zip"
+        S3ObjectKey = "appspec.zip"
       }
     }
   }
@@ -106,16 +106,12 @@ resource "aws_codepipeline" "default" {
       name            = "CodeDeploy"
       category        = "Deploy"
       owner           = "AWS"
-      provider        = "CodeDeployToECS"
+      provider        = "CodeDeploy"
       version         = "1"
       input_artifacts = ["SourceOutput"]
       configuration = {
         ApplicationName                = local.container_name
         DeploymentGroupName            = local.container_name
-        TaskDefinitionTemplateArtifact = "SourceOutput"
-        TaskDefinitionTemplatePath     = "taskdef.json"
-        AppSpecTemplateArtifact        = "SourceOutput"
-        AppSpecTemplatePath            = "appspec.yml"
       }
     }
   }

--- a/s3.tf
+++ b/s3.tf
@@ -41,7 +41,7 @@ resource "aws_s3_object" "appspec_artifacts" {
   count = var.deployment_controller_type == "CODE_DEPLOY" ? 1 : 0
 
   bucket = aws_s3_bucket.appspec_artifacts[0].id
-  key    = "source/appspec.zip"
+  key    = "appspec.zip"
   source = data.archive_file.appspec[0].output_path
   etag   = sha256("${local.appspec_content}${local.taskdef_content}")
   tags   = module.this.tags


### PR DESCRIPTION
### what

- Update s3.tf to put appspec.zip at the top of the bucket filepath because using CodeDeploy within CodePipeline is picky about that for some reason.  
- Update codepipeline.tf to reference the updated appspec.zip location and change the deployment type to `CodeDeploy` instead of `CodeDeployToECS`.

### why

- Prevent CodeDeploy from automatically creating a new task definition when referencing the files needed for `CodeDeployToECS` (both appspec and taskdef.json)

### references

- Tested this with a `dot-com-test` pipeline that i clickops'ed together.  Seemed to work fine; just hoping I got the syntax correct 🤞 

Resolves PLATO-33